### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Templatetags
 Documentation
 *************
 
-For further documentation see http://djangocms-page-tags.readthedocs.org/
+For further documentation see https://djangocms-page-tags.readthedocs.io/
 
 
 .. image:: https://d2weczhvl823v0.cloudfront.net/nephila/djangocms-page-tags/trend.png

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,4 +60,4 @@ For performance reason is advisable to always use a Page object as
 ``page_lookup`` parameter.
 
 
-.. _page_lookup: http://django-cms.readthedocs.org/en/latest/advanced/templatetags.html#page-lookup
+.. _page_lookup: http://docs.django-cms.org/en/release-3.3.x/reference/templatetags.html#page-lookup


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.