### PR TITLE
Django 1.11 / Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 sudo: false
 
 python:
+  - 3.6
   - 3.5
   - 3.4
   - 2.7
@@ -14,13 +15,14 @@ env:
   - TOXENV='pep8'
   - TOXENV='docs'
   - TOXENV='isort'
-  - DJANGO='django18' CMS='cms32'
-  - DJANGO='django18' CMS='cms33'
   - DJANGO='django18' CMS='cms34'
-  - DJANGO='django19' CMS='cms32'
-  - DJANGO='django19' CMS='cms33'
   - DJANGO='django19' CMS='cms34'
   - DJANGO='django110' CMS='cms34'
+  - DJANGO='django111' CMS='cms34'
+  - DJANGO='django18' CMS='cms35'
+  - DJANGO='django19' CMS='cms35'
+  - DJANGO='django110' CMS='cms35'
+  - DJANGO='django111' CMS='cms35'
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
@@ -28,6 +30,7 @@ install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi"
   - "if [[ ${DJANGO}z != 'z' ]]; then export TOXENV=$PYVER-$DJANGO-$CMS; fi"
 
 # command to run tests, e.g. python setup.py test
@@ -48,8 +51,38 @@ matrix:
   - python: 2.7
     env: TOXENV='docs'
   - python: 3.4
+    env: DJANGO='django18' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django19' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django110' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django18' CMS='cms35'
+  - python: 3.4
+    env: DJANGO='django19' CMS='cms35'
+  - python: 3.4
+    env: DJANGO='django110' CMS='cms35'
+  - python: 3.5
+    env: DJANGO='django18' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django19' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django110' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django18' CMS='cms35'
+  - python: 3.5
+    env: DJANGO='django19' CMS='cms35'
+  - python: 3.5
+    env: DJANGO='django110' CMS='cms35'
+  - python: 3.4
     env: TOXENV='pep8'
   - python: 3.4
     env: TOXENV='isort'
   - python: 3.4
+    env: TOXENV='docs'
+  - python: 3.5
+    env: TOXENV='pep8'
+  - python: 3.5
+    env: TOXENV='isort'
+  - python: 3.5
     env: TOXENV='docs'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@
 History
 *******
 
+0.6.0 (unreleased)
+==================
+
+* Add Django 1.11 support
+* Drop django CMS 3.2, 3.3
+
 0.5.0 (2016-12-02)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,11 @@ djangocms-page-tags
 
 Tagged pages for django CMS 3
 
-Python: 2.7, 3.4, 3.5
+Python: 2.7, 3.4, 3.5, 3.6
 
-Django: 1.8 to 1.10
+Django: 1.8 to 1.11
 
-django CMS: 3.2 to 3.4
+django CMS: 3.4 (and develop/3.5)
 
 .. warning:: Since version 0.5, the support for Python 2.6, Python 3.3, Django<1.8 and django CMS<3.2
              has been dropped

--- a/djangocms_page_tags/__init__.py
+++ b/djangocms_page_tags/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-__version__ = '0.5.1.dev1'
+__version__ = '0.6.0.dev1'
 __author__ = 'Iacopo Spalletti <i.spalletti@nephila.it>'

--- a/djangocms_page_tags/cms_toolbars.py
+++ b/djangocms_page_tags/cms_toolbars.py
@@ -6,18 +6,17 @@ from cms.cms_toolbars import PAGE_MENU_SECOND_BREAK
 from cms.toolbar.items import Break
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from cms.utils import get_cms_setting
 from cms.utils.i18n import get_language_list, get_language_object
+from cms.utils.permissions import has_page_permission
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from .models import PageTags, TitleTags
 
 try:
-    from cms.utils.permissions import has_page_permission
-    has_page_change_permission = None
+    from cms.utils import get_cms_setting
 except ImportError:
-    from cms.utils.permissions import has_page_change_permission
+    from cms.utils.conf import get_cms_setting
 
 
 PAGE_TAGS_MENU_TITLE = _('Tags')
@@ -36,23 +35,16 @@ class PageTagsToolbar(CMSToolbar):
 
         # check global permissions if CMS_PERMISSIONS is active
         if get_cms_setting('PERMISSION'):
-            if not has_page_change_permission:
-                has_global_current_page_change_permission = has_page_permission(
-                    self.request.user, self.request.current_page, 'change'
-                )
-            else:
-                has_global_current_page_change_permission = has_page_change_permission(
-                    self.request
-                )
+            has_global_current_page_change_permission = has_page_permission(
+                self.request.user, self.request.current_page, 'change'
+            )
         else:
             has_global_current_page_change_permission = False
             # check if user has page edit permission
-        if not has_page_change_permission:
-            can_change = (self.request.current_page and
-                          self.request.current_page.has_change_permission(self.request.user))
-        else:
-            can_change = (self.request.current_page and
-                          self.request.current_page.has_change_permission(self.request))
+        can_change = (
+            self.request.current_page and
+            self.request.current_page.has_change_permission(self.request.user)
+        )
         if has_global_current_page_change_permission or can_change:
             not_edit_mode = not self.toolbar.edit_mode
             tags_menu = self.toolbar.get_or_create_menu('page')

--- a/djangocms_page_tags/utils.py
+++ b/djangocms_page_tags/utils.py
@@ -117,8 +117,13 @@ def get_page_tags_from_request(request, page_lookup, lang, site, title=False):
     :type: List
     """
     from cms.templatetags.cms_tags import _get_page_by_untyped_arg
-    from cms.utils import get_language_from_request, get_cms_setting, get_site_id
+    from cms.utils import get_language_from_request, get_site_id
     from django.core.cache import cache
+
+    try:
+        from cms.utils import get_cms_setting
+    except ImportError:
+        from cms.utils.conf import get_cms_setting
 
     site_id = get_site_id(site)
     if lang is None:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=(
-        'django-cms>=3.2',
+        'django-cms>=3.4',
         'django-taggit>=0.11.2',
         'django-taggit-autosuggest',
         'django-classy-tags>=0.3.4.1',
@@ -52,10 +52,12 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -24,7 +24,7 @@ class TemplateTagsTest(BaseTest):
         tags = Tag.objects.filter(name__in=('pagetag.1', 'pagetag.2'))
 
         request = self.get_page_request(page1.get_public_object(), AnonymousUser())
-        response = details(request, '')
+        response = details(request, None)
         self.assertContains(response, '<li>pagetag.1</li>')
         self.assertContains(response, '<li>pagetag.2</li>')
 
@@ -40,6 +40,6 @@ class TemplateTagsTest(BaseTest):
         tags = Tag.objects.filter(name__in=('titletag.1', 'titletag.2'))
 
         request = self.get_page_request(page2.get_public_object(), AnonymousUser())
-        response = details(request, '')
+        response = details(request, None)
         self.assertContains(response, '<li>titletag.2</li>')
         self.assertContains(response, '<li>titletag.1</li>')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,isort,py{35,34,27}-django{110}-cms{34},py{35,34,27}-django{19}-cms{34,33,32},py{35,34,27}-django{18}-cms{34,33,32}
+envlist = docs,pep8,isort,py{36,35,34,27}-django{111,110,19,18}-cms{35,34}
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test
@@ -11,9 +11,10 @@ deps =
     django19: django-polymorphic<0.9
     django110: Django>=1.10,<1.11
     django110: django-taggit>=0.18
-    cms32: https://github.com/divio/django-cms/archive/release/3.2.x.zip
-    cms33: https://github.com/divio/django-cms/archive/release/3.3.x.zip
+    django111: Django>=1.11,<2.0
+    django111: django-taggit>=0.18
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
+    cms35: https://github.com/divio/django-cms/archive/develop.zip
     -r{toxinidir}/requirements-test.txt
 
 [testenv:pep8]
@@ -30,8 +31,7 @@ skip_install = true
 deps =
     sphinx
     sphinx-rtd-theme
-    Django<1.10
-    django-polymorphic<0.9
+    Django<2.0
     -rrequirements-test.txt
 changedir=docs
 skip_install = true


### PR DESCRIPTION
* Add Django 1.11
* Add Python 3.6
* Drop django CMS 3.2, 3.3
* Preliminary support for django CMS develop/3.5