### PR TITLE
Use new django CMS 3.5 node object when needed

### DIFF
--- a/djangocms_page_tags/cms_toolbars.py
+++ b/djangocms_page_tags/cms_toolbars.py
@@ -74,8 +74,12 @@ class PageTagsToolbar(CMSToolbar):
                 tags_menu.add_modal_item(PAGE_TAGS_ITEM_TITLE, url=url, disabled=not_edit_mode,
                                          position=position)
             # Title tags
+            try:
+                site_id = self.page.node.site_id
+            except AttributeError:  # CMS_3_4
+                site_id = self.page.site_id
             for title in self.page.title_set.filter(
-                language__in=get_language_list(self.page.site_id)
+                language__in=get_language_list(site_id)
             ):
                 try:
                     title_extension = TitleTags.objects.get(extended_object_id=title.pk)

--- a/djangocms_page_tags/models.py
+++ b/djangocms_page_tags/models.py
@@ -40,32 +40,48 @@ extension_pool.register(TitleTags)
 # Cache cleanup when deleting pages / editing page extensions
 @receiver(pre_delete, sender=Page)
 def cleanup_page(sender, instance, **kwargs):
+    try:
+        site_id = instance.node.site_id
+    except AttributeError:  # CMS_3_4
+        site_id = instance.site_id
     key = get_cache_key(
-        None, instance, '', instance.site_id, False
+        None, instance, '', site_id, False
     )
     cache.delete(key)
 
 
 @receiver(pre_delete, sender=Title)
 def cleanup_title(sender, instance, **kwargs):
+    try:
+        site_id = instance.page.node.site_id
+    except AttributeError:  # CMS_3_4
+        site_id = instance.page.site_id
     key = get_cache_key(
-        None, instance.page, instance.language, instance.page.site_id, True
+        None, instance.page, instance.language, site_id, True
     )
     cache.delete(key)
 
 
 @receiver(post_save, sender=PageTags)
 def cleanup_pagetags(sender, instance, **kwargs):
+    try:
+        site_id = instance.extended_object.node.site_id
+    except AttributeError:  # CMS_3_4
+        site_id = instance.extended_object.site_id
     key = get_cache_key(
-        None, instance.extended_object, '', instance.extended_object.site_id, False
+        None, instance.extended_object, '', site_id, False
     )
     cache.delete(key)
 
 
 @receiver(post_save, sender=TitleTags)
 def cleanup_titletags(sender, instance, **kwargs):
+    try:
+        site_id = instance.extended_object.page.node.site_id
+    except AttributeError:  # CMS_3_4
+        site_id = instance.extended_object.page.site_id
     key = get_cache_key(
         None, instance.extended_object.page, instance.extended_object.language,
-        instance.extended_object.page.site_id, True
+        site_id, True
     )
     cache.delete(key)

--- a/djangocms_page_tags/utils.py
+++ b/djangocms_page_tags/utils.py
@@ -13,7 +13,10 @@ def get_cache_key(request, page, lang, site_id, title):
     if not isinstance(page, Page):
         page = _get_page_by_untyped_arg(page, request, site_id)
     if not site_id:
-        site_id = page.site_id
+        try:
+            site_id = page.node.site_id
+        except AttributeError:  # CMS_3_4
+            site_id = page.site_id
     if not title:
         return _get_cache_key('page_tags', page, '', site_id) + '_type:tags_list'
     else:


### PR DESCRIPTION
Let's use the new `page.node` object in django CMS 3.5+ 