### PR TITLE
Fix for change to `edit_mode` in CMS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 
 # Packages
+.eggs
 *.egg
 *.egg-info
 dist
@@ -30,6 +31,11 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
+env
+venv
+.env
+.venv
 
 # Complexity
 output/*.html

--- a/djangocms_page_tags/cms_toolbars.py
+++ b/djangocms_page_tags/cms_toolbars.py
@@ -8,7 +8,10 @@ from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.i18n import get_language_list, get_language_object
 from cms.utils.permissions import has_page_permission
-from django.core.urlresolvers import NoReverseMatch, reverse
+try:
+    from django.core.urlresolvers import NoReverseMatch, reverse
+except ImportError:
+    from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from .models import PageTags, TitleTags
@@ -46,7 +49,11 @@ class PageTagsToolbar(CMSToolbar):
             self.request.current_page.has_change_permission(self.request.user)
         )
         if has_global_current_page_change_permission or can_change:
-            not_edit_mode = not self.toolbar.edit_mode
+            try:
+                not_edit_mode = not self.toolbar.edit_mode
+            except AttributeError:
+                not_edit_mode = not self.toolbar.edit_mode_active
+
             tags_menu = self.toolbar.get_or_create_menu('page')
             super_item = tags_menu.find_first(Break, identifier=PAGE_MENU_SECOND_BREAK) + 1
             tags_menu = tags_menu.get_or_create_menu(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = docs,pep8,isort,py{36,35,34,27}-django{111,110,19,18}-cms{35,34}
+envlist =
+    docs,pep8,isort,
+    py{36,35,34,27}-django{111,110,19,18}-cms{36,35,34}
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test
@@ -15,7 +17,8 @@ deps =
     django111: django-taggit>=0.18
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
     cms35: https://github.com/divio/django-cms/archive/release/3.5.x.zip
-    -r{toxinidir}/requirements-test.txt
+    cms36: https://github.com/divio/django-cms/archive/release/3.6.x.zip
+    -r {toxinidir}/requirements-test.txt
 
 [testenv:pep8]
 deps = flake8
@@ -32,7 +35,7 @@ deps =
     sphinx
     sphinx-rtd-theme
     Django<2.0
-    -rrequirements-test.txt
+    -r requirements-test.txt
 changedir=docs
 skip_install = true
 commands=


### PR DESCRIPTION
Added `try/except` block for the old `edit_mode` attribute vs the new `edit_mode_active` property.

Also added `try/except` on django urls for support going forward.