### PR TITLE
Drop support for Django < 4.2, python 3.10 and django CMS < 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,10 @@ jobs:
     continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9"]
-        django: [42, 41, 32]
-        cms: [311, 39]
+        python-version: ["3.11", "3.10"]
+        django: [42]
+        cms: [311]
         continue-on-error: [true]
-        exclude:
-          - django: 41
-            cms: 39
-          - django: 42
-            cms: 39
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ djangocms-page-tags
 
 Tagged pages for django CMS 3
 
-Python: 3.7, 3.8, 3.9, 3.10
+Python: 3.10, 3.11
 
-Django: 2.2, 3.2
+Django: 4.2
 
-django CMS: 3.7 - 3.10
+django CMS: 3.11
 
 **********
 Quickstart

--- a/changes/76.feature
+++ b/changes/76.feature
@@ -1,0 +1,1 @@
+Drop support for Django < 4.2, python < 3.10 and django CMS < 3.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,27 +19,22 @@ classifiers =
 	License :: OSI Approved :: BSD License
 	Natural Language :: English
 	Framework :: Django
-	Framework :: Django :: 3.2
-	Framework :: Django :: 4.1
 	Framework :: Django :: 4.2
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.7
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 
 [options]
 include_package_data = True
 install_requires =
-	django-cms>=3.7
+	django-cms>=3.11
 	django-taggit>=0.11.2
 	django-taggit-autosuggest
 	django-classy-tags>=0.3.4.1
 setup_requires =
 	setuptools
 packages = djangocms_page_tags
-python_requires = >=3.7
+python_requires = >=3.10
 test_suite = cms_helper.run
 zip_safe = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,17 +8,13 @@ envlist =
     ruff
     pypi-description
     towncrier
-    py{311,310,39}-django{42,41}-cms{311}
-    py{311,310,39}-django{32}-cms{311,39}
+    py{311,310}-django{42}-cms{311}
 minversion = 3.22
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py djangocms_page_tags test {posargs}
 deps =
-    django32: Django~=3.2.0
-    django41: Django~=4.1.0
     django42: Django~=4.2.0
-    cms39: https://github.com/django-cms/django-cms/archive/release/3.9.x.zip
     cms311: https://github.com/yakky/django-cms/archive/release/3.11.x.zip
     -r{toxinidir}/requirements-test.txt
 passenv =


### PR DESCRIPTION
# Description

Drop support for Django < 4.2, python 3.10 and django CMS < 3.11

## References

Fix #76 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-page-tags.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-page-tags.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [ ] Tests added
