### PR TITLE
fix: pin ruff version to 0.15.22

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.16.0'
+    rev: 'v0.15.22'
     hooks:
       - id: ruff
   - repo: https://github.com/asottile/pyupgrade
@@ -50,5 +50,4 @@ repos:
         pass_filenames: false
         always_run: true
 ci:
-  skip:
-    - towncrier
+  skip: [towncrier,ruff]

--- a/changes/138.bugfix
+++ b/changes/138.bugfix
@@ -1,0 +1,1 @@
+Pin ruff version to 0.15.22

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands =
     {envpython} -minterrogate -c pyproject.toml djangocms_page_tags tests
 deps =
     interrogate
-    ruff
+    ruff~=0.15.22
 skip_install = true
 
 [testenv:isort]


### PR DESCRIPTION
# Description

Pin ruff version to 0.15.22

## References

Fix #138

# Checklist

* [x] I have read the [contribution guide](https://djangocms-page-tags.readthedocs.io/en/latest/contributing.html)
* [] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-page-tags.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
